### PR TITLE
Add react-hot-loader

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+	"presets": [
+		"@babel/preset-env",
+		"@babel/preset-react",
+	],
+	"plugins": [
+		"react-hot-loader/babel",
+	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -895,6 +895,18 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@hot-loader/react-dom": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-16.8.6.tgz",
+      "integrity": "sha512-+JHIYh33FVglJYZAUtRjfT5qZoT2mueJGNzU5weS2CVw26BgbxGKSujlJhO85BaRbg8sqNWyW1hYBILgK3ZCgA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.13.6"
+      }
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2319,6 +2331,12 @@
         "entities": "^1.1.1"
       }
     },
+    "dom-walk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
+      "dev": true
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -2748,6 +2766,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "faye-websocket": {
@@ -3536,6 +3560,16 @@
         }
       }
     },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "global-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
@@ -3698,6 +3732,15 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hoist-non-react-statics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "dev": true,
+      "requires": {
+        "react-is": "^16.7.0"
       }
     },
     "homedir-polyfill": {
@@ -4488,6 +4531,15 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -5319,10 +5371,41 @@
         "scheduler": "^0.13.6"
       }
     },
+    "react-hot-loader": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.3.tgz",
+      "integrity": "sha512-XBhxogFOxEh8L4Ykdk2mp704Xc/eoy+bwadEYMvmBhjAz3wg+DfMpINMkA+kLTRDinqwjssDfA9DhUJznRjvuA==",
+      "dev": true,
+      "requires": {
+        "fast-levenshtein": "^2.0.6",
+        "global": "^4.3.0",
+        "hoist-non-react-statics": "^3.3.0",
+        "loader-utils": "^1.1.0",
+        "lodash": "^4.17.11",
+        "prop-types": "^15.6.1",
+        "react-lifecycles-compat": "^3.0.4",
+        "shallowequal": "^1.0.2",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
+    },
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "dev": true
     },
     "readable-stream": {
       "version": "2.3.6",
@@ -5792,6 +5875,12 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -6723,6 +6812,30 @@
         "supports-color": "6.1.0",
         "v8-compile-cache": "2.0.3",
         "yargs": "13.2.4"
+      }
+    },
+    "webpack-config-utils": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/webpack-config-utils/-/webpack-config-utils-2.3.1.tgz",
+      "integrity": "sha512-0uC5uj7sThFTePTQjfpe5Wqcbw3KSCxqswOmW96lwk2ZI2CU098rWY2ZqOVGJQYJ3hfEltmjcLNkKutw8LJAlg==",
+      "dev": true,
+      "requires": {
+        "webpack-combine-loaders": "2.0.4"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "webpack-combine-loaders": {
+          "version": "2.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "qs": "^6.5.2"
+          }
+        }
       }
     },
     "webpack-dev-middleware": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack --env.mode=production --config webpack.config.js",
-    "dev": "webpack-dev-server --env.mode=development"
+    "dev": "webpack-dev-server --hot --env.mode=development"
   },
   "keywords": [],
   "author": "",
@@ -18,11 +18,14 @@
     "@babel/core": "^7.5.0",
     "@babel/preset-env": "^7.5.0",
     "@babel/preset-react": "^7.0.0",
+    "@hot-loader/react-dom": "^16.8.6",
     "babel-loader": "^8.0.6",
     "html-webpack-plugin": "^3.2.0",
     "html-webpack-root-plugin": "^0.10.0",
+    "react-hot-loader": "^4.12.3",
     "webpack": "^4.35.2",
     "webpack-cli": "^3.3.5",
+    "webpack-config-utils": "^2.3.1",
     "webpack-dev-server": "^3.7.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
+import { hot } from 'react-hot-loader/root'
 import { say } from './say'
 import React from 'react'
 import { render } from 'react-dom'
 
 say('hello whirled')
 
-const App = () => <main>Hello from React</main>
+const App = hot(() => <main>Hello from React</main>)
 
 render(<App />, document.getElementById('root'))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,20 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const HtmlWebpackRootPlugin = require('html-webpack-root-plugin')
+const { getIfUtils, removeEmpty } = require('webpack-config-utils')
 
 module.exports = ({ mode }) => {
+  const { ifProduction, ifNotProduction } = getIfUtils(mode)
+
   return {
     mode,
     output: {
       filename: 'bundle.js',
     },
+    resolve: removeEmpty({
+      alias: ifNotProduction({
+        'react-dom': '@hot-loader/react-dom',
+      }),
+    }),
     plugins: [new HtmlWebpackPlugin(), new HtmlWebpackRootPlugin()],
     module: {
       rules: [


### PR DESCRIPTION
This commit adds react-hot-loader and it's version of react-🔥-dom so
that not only does hot loading work, but so does hot reloading with
hooks.